### PR TITLE
refactor: switch message packet to struct/enum of arrays

### DIFF
--- a/crates/module_system/collections/src/store_client.rs
+++ b/crates/module_system/collections/src/store_client.rs
@@ -3,7 +3,7 @@ use ixc_core::Context;
 use ixc_core_macros::message_selector;
 use ixc_message_api::code::ErrorCode;
 use ixc_message_api::handler::InvokeParams;
-use ixc_message_api::message::{MessageSelector, Param, Request, Response};
+use ixc_message_api::message::{MessageSelector, Request, Response};
 
 const GET_SELECTOR: MessageSelector = message_selector!("ixc.store.v1.get");
 const SET_SELECTOR: MessageSelector = message_selector!("ixc.store.v1.set");
@@ -14,9 +14,10 @@ pub(crate) struct KVStoreClient;
 impl KVStoreClient {
     pub(crate) fn get<'a>(&self, ctx: &'a Context, key: &[u8]) -> ClientResult<Option<&'a [u8]>> {
         let res = dynamic_query_state(ctx, &Request::new1(GET_SELECTOR, key.into()))?;
-        match res.out1() {
-            Param::Slice(res_bz) => Ok(Some(res_bz)),
-            _ => Ok(None),
+        if let Some(res_bz) = res.out1().as_slice() {
+            Ok(Some(res_bz))
+        } else {
+            Ok(None)
         }
     }
 

--- a/crates/module_system/core/src/low_level.rs
+++ b/crates/module_system/core/src/low_level.rs
@@ -80,7 +80,7 @@ fn decode_message_response<'a, 'b, M: MessageBase<'b>>(
     match res {
         Ok(res) => {
             let cdc = M::Codec::default();
-            let res = M::Response::<'a>::decode_value(&cdc, res.out1(), context.memory_manager())?;
+            let res = M::Response::<'a>::decode_value(&cdc, &res.out1(), context.memory_manager())?;
             Ok(res)
         }
         Err(e) => {

--- a/crates/module_system/message_api/src/message.rs
+++ b/crates/module_system/message_api/src/message.rs
@@ -43,8 +43,7 @@ pub struct Param<'a> {
     typ: ParamType,
 }
 
-#[derive(Default, Clone, Copy)]
-#[non_exhaustive]
+#[derive(Default, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 enum ParamType {
     /// An empty response.
@@ -236,6 +235,43 @@ impl<'a> Param<'a> {
         match self.typ {
             ParamType::AccountID => unsafe { Ok(self.value.account_id) },
             _ => Err(ErrorCode::SystemCode(SystemCode::EncodingError)),
+        }
+    }
+
+    /// Returns true if the parameter is empty.
+    pub fn is_empty(&self) -> bool {
+        self.typ == ParamType::Empty
+    }
+
+    /// Returns the paremeter as a slice if it is a slice.
+    pub fn as_slice(&self) -> Option<&'a [u8]> {
+        match self.typ {
+            ParamType::Slice => unsafe { Some(self.value.slice) },
+            _ => None,
+        }
+    }
+
+    /// Returns the parameter as a string if it is a string.
+    pub fn as_string(&self) -> Option<&'a str> {
+        match self.typ {
+            ParamType::String => unsafe { Some(self.value.string) },
+            _ => None,
+        }
+    }
+
+    /// Returns the parameter as a u128 if it is a u128.
+    pub fn as_u128(&self) -> Option<u128> {
+        match self.typ {
+            ParamType::U128 => unsafe { Some(self.value.u128) },
+            _ => None,
+        }
+    }
+
+    /// Returns the parameter as an account ID if it is an account ID.
+    pub fn as_account_id(&self) -> Option<AccountID> {
+        match self.typ {
+            ParamType::AccountID => unsafe { Some(self.value.account_id) },
+            _ => None,
         }
     }
 }

--- a/crates/module_system/message_api/src/message.rs
+++ b/crates/module_system/message_api/src/message.rs
@@ -20,11 +20,11 @@ pub type MessageSelector = u64;
 #[non_exhaustive]
 #[repr(C)]
 pub struct Request<'a> {
-    /// The message selector.
-    message_selector: MessageSelector,
-    /// The inputs to the message.
-    /// There can be up to three inputs.
-    inputs: [Param<'a>; 3],
+    // this struct is packed in this order so that we have the largest and most aligned items first
+    // and then smaller and less aligned items last
+    inputs_values: [ParamValue<'a>; 3], // size 16 * 3, aligned to 16 bytes
+    message_selector: MessageSelector,  // size 8, aligned to 8 bytes
+    inputs_types: [ParamType; 3],       // size 3, aligned to 1 byte
 }
 
 /// A message response.
@@ -32,27 +32,47 @@ pub struct Request<'a> {
 #[derive(Default)]
 #[repr(C)]
 pub struct Response<'a> {
-    /// The outputs of the message.
-    /// There can be up to two outputs.
-    outputs: [Param<'a>; 2],
+    outputs_values: [ParamValue<'a>; 2], // size 16 * 2, aligned to 16 bytes
+    outputs_types: [ParamType; 2],       // size 2, aligned to 1 byte
 }
 
 /// A message response.
 #[derive(Default)]
+pub struct Param<'a> {
+    value: ParamValue<'a>,
+    typ: ParamType,
+}
+
+#[derive(Default, Clone, Copy)]
 #[non_exhaustive]
-#[repr(C, u8)]
-pub enum Param<'a> {
+#[repr(u8)]
+enum ParamType {
     /// An empty response.
     #[default]
     Empty,
     /// A slice parameter.
-    Slice(&'a [u8]),
+    Slice,
     /// A String parameter.
-    String(&'a str),
+    String,
     /// A u128 parameter.
-    U128(u128),
+    U128,
     /// An account ID parameter.
-    AccountID(AccountID),
+    AccountID,
+}
+
+#[derive(Clone, Copy)]
+union ParamValue<'a> {
+    empty: (),
+    slice: &'a [u8],
+    string: &'a str,
+    u128: u128,
+    account_id: AccountID,
+}
+
+impl<'a> Default for ParamValue<'a> {
+    fn default() -> Self {
+        Self { empty: () }
+    }
 }
 
 impl<'a> Message<'a> {
@@ -80,7 +100,8 @@ impl<'a> Request<'a> {
     pub fn new(message_selector: MessageSelector) -> Self {
         Self {
             message_selector,
-            inputs: Default::default(),
+            inputs_values: Default::default(),
+            inputs_types: Default::default(),
         }
     }
 
@@ -88,7 +109,8 @@ impl<'a> Request<'a> {
     pub fn new1(message_selector: MessageSelector, in1: Param<'a>) -> Self {
         Self {
             message_selector,
-            inputs: [in1, Param::Empty, Param::Empty],
+            inputs_values: [in1.value, ParamValue::default(), ParamValue::default()],
+            inputs_types: [in1.typ, ParamType::Empty, ParamType::Empty],
         }
     }
 
@@ -96,7 +118,8 @@ impl<'a> Request<'a> {
     pub fn new2(message_selector: MessageSelector, in1: Param<'a>, in2: Param<'a>) -> Self {
         Self {
             message_selector,
-            inputs: [in1, in2, Param::Empty],
+            inputs_values: [in1.value, in2.value, ParamValue::default()],
+            inputs_types: [in1.typ, in2.typ, ParamType::Empty],
         }
     }
 
@@ -109,7 +132,8 @@ impl<'a> Request<'a> {
     ) -> Self {
         Self {
             message_selector,
-            inputs: [in1, in2, in3],
+            inputs_values: [in1.value, in2.value, in3.value],
+            inputs_types: [in1.typ, in2.typ, in3.typ],
         }
     }
 
@@ -119,18 +143,27 @@ impl<'a> Request<'a> {
     }
 
     /// Get the first input parameter.
-    pub fn in1(&self) -> &Param<'a> {
-        &self.inputs[0]
+    pub fn in1(&self) -> Param<'a> {
+        Param {
+            typ: self.inputs_types[0],
+            value: self.inputs_values[0],
+        }
     }
 
     /// Get the second input parameter.
-    pub fn in2(&self) -> &Param<'a> {
-        &self.inputs[1]
+    pub fn in2(&self) -> Param<'a> {
+        Param {
+            typ: self.inputs_types[1],
+            value: self.inputs_values[1],
+        }
     }
 
     /// Get the third input parameter.
-    pub fn in3(&self) -> &Param<'a> {
-        &self.inputs[2]
+    pub fn in3(&self) -> Param<'a> {
+        Param {
+            typ: self.inputs_types[2],
+            value: self.inputs_values[2],
+        }
     }
 }
 
@@ -143,57 +176,65 @@ impl<'a> Response<'a> {
     /// Create a new response with one output.
     pub fn new1(out1: Param<'a>) -> Self {
         Self {
-            outputs: [out1, Param::Empty],
+            outputs_values: [out1.value, ParamValue::default()],
+            outputs_types: [out1.typ, ParamType::Empty],
         }
     }
 
     /// Create a new response with two outputs.
     pub fn new2(out1: Param<'a>, out2: Param<'a>) -> Self {
         Self {
-            outputs: [out1, out2],
+            outputs_values: [out1.value, out2.value],
+            outputs_types: [out1.typ, out2.typ],
         }
     }
 
     /// Get the first output parameter.
-    pub fn out1(&self) -> &Param<'a> {
-        &self.outputs[0]
+    pub fn out1(&self) -> Param<'a> {
+        Param {
+            typ: self.outputs_types[0],
+            value: self.outputs_values[0],
+        }
     }
 
     /// Get the second output parameter.
-    pub fn out2(&self) -> &Param<'a> {
-        &self.outputs[1]
+    pub fn out2(&self) -> Param<'a> {
+        Param {
+            typ: self.outputs_types[1],
+            value: self.outputs_values[1],
+        }
     }
 }
 
 impl<'a> Param<'a> {
     /// Expect the parameter to be a slice or return an encoding error.
     pub fn expect_bytes(&self) -> Result<&'a [u8], ErrorCode> {
-        match self {
-            Param::Slice(slice) => Ok(slice),
+        match self.typ {
+            ParamType::Slice => unsafe {Ok(self.value.slice) },
             _ => Err(ErrorCode::SystemCode(SystemCode::EncodingError)),
         }
     }
 
     /// Expect the parameter to be a string or return an encoding error.
     pub fn expect_string(&self) -> Result<&'a str, ErrorCode> {
-        match self {
-            Param::String(string) => Ok(string),
+        match self.typ {
+            ParamType::String => unsafe {Ok(self.value.string) },
             _ => Err(ErrorCode::SystemCode(SystemCode::EncodingError)),
         }
     }
 
     /// Expect the parameter to be a u128 or return an encoding error.
     pub fn expect_u128(&self) -> Result<u128, ErrorCode> {
-        match self {
-            Param::U128(u128) => Ok(*u128),
+        match self.typ {
+            ParamType::U128 => unsafe {Ok(self.value.u128) },
             _ => Err(ErrorCode::SystemCode(SystemCode::EncodingError)),
         }
     }
 
     /// Expect the parameter to be an account ID or return an encoding error.
     pub fn expect_account_id(&self) -> Result<AccountID, ErrorCode> {
-        match self {
-            Param::AccountID(account_id) => Ok(*account_id),
+        match self.typ {
+            ParamType::AccountID => unsafe {Ok(self.value.account_id) },
             _ => Err(ErrorCode::SystemCode(SystemCode::EncodingError)),
         }
     }
@@ -201,24 +242,59 @@ impl<'a> Param<'a> {
 
 impl<'a> From<&'a [u8]> for Param<'a> {
     fn from(slice: &'a [u8]) -> Self {
-        Param::Slice(slice)
+        Param {
+            typ: ParamType::Slice,
+            value: ParamValue { slice },
+        }
     }
 }
 
 impl<'a> From<&'a str> for Param<'a> {
     fn from(string: &'a str) -> Self {
-        Param::String(string)
+        Param {
+            typ: ParamType::String,
+            value: ParamValue { string },
+        }
     }
 }
 
-impl From<u128> for Param<'_> {
+impl<'a> From<u128> for Param<'a> {
     fn from(u128: u128) -> Self {
-        Param::U128(u128)
+        Param {
+            typ: ParamType::U128,
+            value: ParamValue { u128 },
+        }
     }
 }
 
 impl From<AccountID> for Param<'_> {
     fn from(account_id: AccountID) -> Self {
-        Param::AccountID(account_id)
+        Param {
+            typ: ParamType::AccountID,
+            value: ParamValue { account_id },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    extern crate std;
+    use std::println;
+
+    #[test]
+    fn test_size_of() {
+        // before
+        // size of Request: 112
+        // size of Response: 64
+        // size of Message: 128
+
+        // after
+        // size of Request: 64
+        // size of Response: 48
+        // size of Message: 80
+        println!("size of Request: {:?}", std::mem::size_of::<Request>());
+        println!("size of Response: {:?}", std::mem::size_of::<Response>());
+        println!("size of Message: {:?}", std::mem::size_of::<Message>());
     }
 }

--- a/crates/module_system/message_api/src/message.rs
+++ b/crates/module_system/message_api/src/message.rs
@@ -210,7 +210,7 @@ impl<'a> Param<'a> {
     /// Expect the parameter to be a slice or return an encoding error.
     pub fn expect_bytes(&self) -> Result<&'a [u8], ErrorCode> {
         match self.typ {
-            ParamType::Slice => unsafe {Ok(self.value.slice) },
+            ParamType::Slice => unsafe { Ok(self.value.slice) },
             _ => Err(ErrorCode::SystemCode(SystemCode::EncodingError)),
         }
     }
@@ -218,7 +218,7 @@ impl<'a> Param<'a> {
     /// Expect the parameter to be a string or return an encoding error.
     pub fn expect_string(&self) -> Result<&'a str, ErrorCode> {
         match self.typ {
-            ParamType::String => unsafe {Ok(self.value.string) },
+            ParamType::String => unsafe { Ok(self.value.string) },
             _ => Err(ErrorCode::SystemCode(SystemCode::EncodingError)),
         }
     }
@@ -226,7 +226,7 @@ impl<'a> Param<'a> {
     /// Expect the parameter to be a u128 or return an encoding error.
     pub fn expect_u128(&self) -> Result<u128, ErrorCode> {
         match self.typ {
-            ParamType::U128 => unsafe {Ok(self.value.u128) },
+            ParamType::U128 => unsafe { Ok(self.value.u128) },
             _ => Err(ErrorCode::SystemCode(SystemCode::EncodingError)),
         }
     }
@@ -234,7 +234,7 @@ impl<'a> Param<'a> {
     /// Expect the parameter to be an account ID or return an encoding error.
     pub fn expect_account_id(&self) -> Result<AccountID, ErrorCode> {
         match self.typ {
-            ParamType::AccountID => unsafe {Ok(self.value.account_id) },
+            ParamType::AccountID => unsafe { Ok(self.value.account_id) },
             _ => Err(ErrorCode::SystemCode(SystemCode::EncodingError)),
         }
     }
@@ -273,28 +273,5 @@ impl From<AccountID> for Param<'_> {
             typ: ParamType::AccountID,
             value: ParamValue { account_id },
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    extern crate std;
-    use std::println;
-
-    #[test]
-    fn test_size_of() {
-        // before
-        // size of Request: 112
-        // size of Response: 64
-        // size of Message: 128
-
-        // after
-        // size of Request: 64
-        // size of Response: 48
-        // size of Message: 80
-        println!("size of Request: {:?}", std::mem::size_of::<Request>());
-        println!("size of Response: {:?}", std::mem::size_of::<Response>());
-        println!("size of Message: {:?}", std::mem::size_of::<Message>());
     }
 }

--- a/crates/module_system/message_api/src/message.rs
+++ b/crates/module_system/message_api/src/message.rs
@@ -68,7 +68,7 @@ union ParamValue<'a> {
     account_id: AccountID,
 }
 
-impl<'a> Default for ParamValue<'a> {
+impl Default for ParamValue<'_> {
     fn default() -> Self {
         Self { empty: () }
     }
@@ -294,7 +294,7 @@ impl<'a> From<&'a str> for Param<'a> {
     }
 }
 
-impl<'a> From<u128> for Param<'a> {
+impl From<u128> for Param<'_> {
     fn from(u128: u128) -> Self {
         Param {
             typ: ParamType::U128,


### PR DESCRIPTION
Before:
```
        size of Request: 112
        size of Response: 64
        size of Message: 128
```        

After:
```
        size of Request: 64
        size of Response: 48
        size of Message: 80
```